### PR TITLE
Obtain retail price and sale price from products

### DIFF
--- a/src/SpeckCatalog/Model/Choice/Relational.php
+++ b/src/SpeckCatalog/Model/Choice/Relational.php
@@ -26,19 +26,19 @@ class Relational extends Base
         return 0;
     }
 
-    public function getRecursivePrice($parentProductPrice=0)
+    public function getRecursivePrice($parentProductPrice=0, $retailPrice=false)
     {
         if ($this->has('product')) {
-            $productPrice = $this->getProduct()->getRecursivePrice();
-        	return $productPrice + $this->getAdjustmentPrice($productPrice);
+            $productPrice = $this->getProduct()->getRecursivePrice($retailPrice);
+            return $productPrice + $this->getAdjustmentPrice($productPrice);
         } else {
-        	$adjustedPrice = $this->getAdjustedPrice();
+            $adjustedPrice = $this->getAdjustedPrice($retailPrice);
             $adjustmentPrice = $adjustedPrice - $parentProductPrice;
 
             $price = 0;
             if ($this->has('options')) {
                 foreach($this->getOptions() as $option) {
-                    $price += $option->getRecursivePrice($adjustedPrice);
+                    $price += $option->getRecursivePrice($adjustedPrice, $retailPrice);
                 }
             }
 
@@ -46,24 +46,24 @@ class Relational extends Base
         }
     }
 
-    public function getAdjustedPrice()
+    public function getAdjustedPrice($retailPrice=false)
     {
-        $parentProductPrice = $this->getParentProductPrice();
+        $parentProductPrice = $this->getParentProductPrice($retailPrice);
         return $parentProductPrice + $this->getAdjustmentPrice($parentProductPrice);
     }
 
-    public function getParentProductPrice()
+    public function getParentProductPrice($retailPrice=false)
     {
         if ($this->has('parent')) {
-            return $this->getParent()->getAdjustedPrice();
+            return $this->getParent()->getAdjustedPrice($retailPrice);
         }
         return 0;
     }
 
 
-	public function getAdjustmentPrice($parentPrice)
-	{
-	    if($this->getPriceDiscountFixed()) {
+    public function getAdjustmentPrice($parentPrice)
+    {
+        if($this->getPriceDiscountFixed()) {
             return -$this->getPriceDiscountFixed();
         } elseif($this->getPriceDiscountPercent()) {
             return $parentPrice * -($this->getPriceDiscountPercent()/100);
@@ -74,7 +74,7 @@ class Relational extends Base
         } else {
             return 0;
         }
-	}
+    }
 
 
     public function getItemNumber()
@@ -151,15 +151,15 @@ class Relational extends Base
         return $this;
     }
 
-    public function getAddPrice()
+    public function getAddPrice($retailPrice=false)
     {
         if($this->addPrice) {
             return $this->addPrice;
         } elseif ($this->has('product')) {
-            $productPrice = $this->getProduct()->getPrice();
+            $productPrice = $this->getProduct()->getPrice($retailPrice);
             return $productPrice + $this->getAdjustmentPrice($productPrice);
         } else {
-            return $this->getAdjustedPrice() - $this->getParentProductPrice();
+            return $this->getAdjustedPrice($retailPrice) - $this->getParentProductPrice($retailPrice);
         }
     }
 

--- a/src/SpeckCatalog/Model/Option/Relational.php
+++ b/src/SpeckCatalog/Model/Option/Relational.php
@@ -21,13 +21,13 @@ class Relational extends Base
         return $this->optionId;
     }
 
-    public function getRecursivePrice($parentProductPrice=0)
+    public function getRecursivePrice($parentProductPrice=0, $retailPrice=false)
     {
         if ($this->getRequired()) {
             if ($this->has('choices')) {
                 $choicePrices = array();
                 foreach($this->getChoices() as $choice) {
-                    $choicePrices[] = $choice->getRecursivePrice($parentProductPrice);
+                    $choicePrices[] = $choice->getRecursivePrice($parentProductPrice, $retailPrice);
                 }
 
                 asort($choicePrices, SORT_NUMERIC);
@@ -39,18 +39,18 @@ class Relational extends Base
     }
 
 
-    public function getAdjustedPrice()
+    public function getAdjustedPrice($retailPrice=false)
     {
-    	$parent = $this->getParent();
-    	if($parent instanceof RelationalProduct) {
-    		return $parent->getPrice();
-    	} else {
-    		if(isset($parent)) {
-				return $parent->getAdjustedPrice();
-    		} else {
-    			return 0;
-    		}
-    	}
+        $parent = $this->getParent();
+        if($parent instanceof RelationalProduct) {
+            return $parent->getPrice($retailPrice);
+        } else {
+            if(isset($parent)) {
+                return $parent->getAdjustedPrice($retailPrice);
+            } else {
+                return 0;
+            }
+        }
     }
 
 

--- a/src/SpeckCatalog/Model/Product/Relational.php
+++ b/src/SpeckCatalog/Model/Product/Relational.php
@@ -22,14 +22,14 @@ class Relational extends Base
         return $this->productId;
     }
 
-    public function getRecursivePrice()
+    public function getRecursivePrice($retailPrice=false)
     {
-        $price = $this->getPrice();
+        $price = $this->getPrice($retailPrice);
 
         $adjustmentPrice = 0;
         if ($this->has('options')) {
             foreach ($this->getOptions() as $option) {
-                $adjustmentPrice += $option->getRecursivePrice($price);
+                $adjustmentPrice += $option->getRecursivePrice($price, $retailPrice);
             }
         }
 
@@ -52,12 +52,12 @@ class Relational extends Base
     }
 
 
-    public function getPrice()
+    public function getPrice($retailPrice=false)
     {
         if ($this->has('uoms')) {
             $uomPrices = array();
             foreach($this->getUoms() as $uom) {
-                $uomPrices[] = $uom->getPrice();
+                $uomPrices[] = $retailPrice ? $uom->getRetail() : $uom->getPrice();
             }
             asort($uomPrices, SORT_NUMERIC);
             return array_shift($uomPrices);
@@ -65,7 +65,7 @@ class Relational extends Base
             $uomPrices = array();
             foreach ($this->getBuilders() as $builder) {
                 foreach($builder->getProduct()->getUoms() as $uom) {
-                    $uomPrices[] = $uom->getPrice();
+                    $uomPrices[] = $retailPrice ? $uom->getRetail() : $uom->getPrice();
                 }
             }
             asort($uomPrices, SORT_NUMERIC);


### PR DESCRIPTION
Altered the recursive price functionality to allow access to obtaining the retail price from the product uom's. I have a case of wanting to offer a discount to the retail price which is setup by setting the retail field in the catalog_product_uom table to a different value to the price field. This funcaitonlity allows access to obtaining either the retail price or the actual sale price (default functionality is to obtain the price for backwards compatibility) This is achieved by passing a $retailPrice boolean through the recusrive price functionality so when UOM prices are obtained it gets the price if $retailPrice if false (default) or retail if $retailPrice is true.