### PR TITLE
Adding PHPUnit framework for unit testing to the project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "evandotpro/edp-sub-layout" : "dev-master"
     },
     "require-dev": {
-        "mockery/mockery": ">=0.7.2"
+        "mockery/mockery": ">=0.7.2",
+        "phpunit/phpunit": "~4.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Adding [PHPUnit framework](https://packagist.org/packages/phpunit/phpunit) for unit testing to the project as mentioned in the wiki. Without PHPUnit, not a lot of testing can be done