### PR TITLE
In ZF 2.4+, the Null filter is now ToNull

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "zendframework/zendframework": "2.*",
+        "zendframework/zendframework": "~2.4",
         "zf-commons/zfc-admin": "0.1.*",
         "speckcommerce/speck-contact": "dev-master",
         "speckcommerce/speck-cart": "dev-master",

--- a/src/SpeckCatalog/Filter/Choice.php
+++ b/src/SpeckCatalog/Filter/Choice.php
@@ -2,6 +2,7 @@
 
 namespace SpeckCatalog\Filter;
 
+use Zend\Filter\ToNull;
 use Zend\InputFilter\InputFilter;
 
 class Choice extends Inputfilter
@@ -12,7 +13,7 @@ class Choice extends Inputfilter
             'name' => 'choice_id',
             'allow_empty' => true,
             'filters'   => array(
-                new \Zend\Filter\Null(\Zend\Filter\Null::TYPE_STRING),
+                new ToNull(ToNull::TYPE_STRING),
             ),
         ));
         $this->add(array(

--- a/src/SpeckCatalog/Filter/Option.php
+++ b/src/SpeckCatalog/Filter/Option.php
@@ -2,6 +2,7 @@
 
 namespace SpeckCatalog\Filter;
 
+use Zend\Filter\ToNull;
 use Zend\InputFilter\InputFilter;
 
 class Option extends InputFilter
@@ -13,7 +14,7 @@ class Option extends InputFilter
             'allow_empty' => true,
             'required' => true,
             'filters'   => array(
-                new \Zend\Filter\Null(\Zend\Filter\Null::TYPE_STRING),
+                new ToNull(ToNull::TYPE_STRING),
             ),
         ));
         $this->add(array(

--- a/src/SpeckCatalog/Filter/Product.php
+++ b/src/SpeckCatalog/Filter/Product.php
@@ -2,6 +2,7 @@
 
 namespace SpeckCatalog\Filter;
 
+use Zend\Filter\ToNull;
 use Zend\InputFilter\InputFilter;
 
 class Product extends InputFilter
@@ -13,7 +14,7 @@ class Product extends InputFilter
             'required'    => 'true',
             'allow_empty' => 'true',
             'filters'   => array(
-                new \Zend\Filter\Null(\Zend\Filter\Null::TYPE_STRING),
+                new ToNull(ToNull::TYPE_STRING),
             ),
         ));
         $this->add(array(

--- a/src/SpeckCatalog/Filter/Spec.php
+++ b/src/SpeckCatalog/Filter/Spec.php
@@ -2,6 +2,7 @@
 
 namespace SpeckCatalog\Filter;
 
+use Zend\Filter\ToNull;
 use Zend\InputFilter\InputFilter;
 
 class Spec extends InputFilter
@@ -12,7 +13,7 @@ class Spec extends InputFilter
             'name' => 'product_id',
             'required' => true,
             'filters'   => array(
-                new \Zend\Filter\Null(\Zend\Filter\Null::TYPE_STRING),
+                new ToNull(ToNull::TYPE_STRING),
             ),
         ));
         $this->add(array(
@@ -20,7 +21,7 @@ class Spec extends InputFilter
             'required' => true,
             'allow_empty' => true,
             'filters'   => array(
-                new \Zend\Filter\Null(\Zend\Filter\Null::TYPE_STRING),
+                new ToNull(ToNull::TYPE_STRING),
             ),
         ));
         $this->add(array(


### PR DESCRIPTION
Update references to the Null filter in SpeckCatalog and up minimum ZF2 version to 2.4+.  This is to avoid future naming collisions with reserved word 'null' in PHP7.  Before this change, using ZF2.4+ with SpeckCatalog would throw up deprecation messages.